### PR TITLE
Previously told user to load a gist ID before hitting explore. I chan…

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -121,7 +121,7 @@ Nicholas and Damien.
 
         <script id="explore-template-noID" type="x-tmpl-mustache">{% raw %}
             <h2>Errors</h2>
-            <p>Please load a gist ID before trying to explore</p>
+            <p>Please load a save ID before trying to explore</p>
             {% endraw %}
         </script>
 


### PR DESCRIPTION
…ged this to save ID so it is the same as everywhere else and will not confuse people